### PR TITLE
Fix hoverpause props typo

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export interface IGlideProps {
   focusAt?: number | string;
   gap?: number;
   autoplay?: number | boolean;
-  hoverPause?: boolean;
+  hoverpause?: boolean;
   keyboard?: boolean;
   bound?: boolean;
   swipeThreshold?: number | boolean;


### PR DESCRIPTION
Hi,

I need autoplay with hoverpause disabled and I found that original Glide property and current one don't match.
I just updated it in types.ts to fit the correct one : hoverpause.

Let me know if anything is missing.